### PR TITLE
fix call provider linsten for actor function only once

### DIFF
--- a/options.go
+++ b/options.go
@@ -25,7 +25,6 @@ func WithNewLinkFunc(inFunc func(core.LinkDefinition) error) ProviderOption {
 				return err
 			}
 
-			go wp.listenForActor(linkdef.ActorId)
 			wp.putLink(linkdef)
 
 			return nil
@@ -41,10 +40,7 @@ func WithDelLinkFunc(inFunc func(core.LinkDefinition) error) ProviderOption {
 			if err != nil {
 				return err
 			}
-			// shutdown specific NATs subscription
-			wp.natsSubscriptions[linkdef.ActorId].Drain()
-			wp.natsSubscriptions[linkdef.ActorId].Unsubscribe()
-			
+
 			wp.deleteLink(linkdef)
 
 			return nil


### PR DESCRIPTION
Now provider sdk will call `listenForActor` every time a link is put, and subscribe when the link is deleted. The topic is always the same, and in rust SDK this is only called once.