### PR TITLE
feat(#10): collecting and sending failed links back to cloud provider via server

### DIFF
--- a/examples/keyvalue-inmemory/go.mod
+++ b/examples/keyvalue-inmemory/go.mod
@@ -1,6 +1,6 @@
 module github.com/wasmCloud/provider-sdk-go/examples/keyvalue-inmemory
 
-go 1.22.3
+go 1.20
 
 require (
 	github.com/wasmCloud/provider-sdk-go v0.0.0-20240124183610-1a92f8d04935

--- a/examples/keyvalue-inmemory/keyvalue.go
+++ b/examples/keyvalue-inmemory/keyvalue.go
@@ -17,8 +17,10 @@ var (
 
 type Provider struct {
 	sync.Map
-	sourceLinks map[string]provider.InterfaceLinkDefinition
-	targetLinks map[string]provider.InterfaceLinkDefinition
+	sourceLinks       map[string]provider.InterfaceLinkDefinition
+	targetLinks       map[string]provider.InterfaceLinkDefinition
+	failedSourceLinks map[string]provider.InterfaceLinkDefinition
+	failedTargetLinks map[string]provider.InterfaceLinkDefinition
 }
 
 func Ok[T any](v T) *wrpc.Result[T, store.Error] {

--- a/examples/keyvalue-inmemory/link.go
+++ b/examples/keyvalue-inmemory/link.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"github.com/wasmCloud/provider-sdk-go"
+	"log"
+)
+
+func (p *Provider) establishSourceLink(link provider.InterfaceLinkDefinition) error {
+	if _, exists := p.sourceLinks[link.Target]; exists {
+		log.Println("Source link already exists, ignoring duplicate", link)
+		return nil
+	}
+
+	if err := p.validateSourceLink(link); err != nil {
+		return err
+	}
+
+	p.sourceLinks[link.Target] = link
+	return nil
+}
+
+func (p *Provider) establishTargetLink(link provider.InterfaceLinkDefinition) error {
+	if _, exists := p.targetLinks[link.SourceID]; exists {
+		log.Println("Target link already exists, ignoring duplicate", link)
+		return nil
+	}
+
+	if err := p.validateTargetLink(link); err != nil {
+		return err
+	}
+
+	p.targetLinks[link.SourceID] = link
+	return nil
+}
+
+func (p *Provider) validateSourceLink(link provider.InterfaceLinkDefinition) error {
+	// TODO: Add validation checks
+	return nil
+}
+
+func (p *Provider) validateTargetLink(link provider.InterfaceLinkDefinition) error {
+	// TODO: Add validation checks
+	return nil
+}

--- a/examples/keyvalue-inmemory/main.go
+++ b/examples/keyvalue-inmemory/main.go
@@ -20,8 +20,10 @@ func main() {
 
 func run() error {
 	p := &Provider{
-		sourceLinks: make(map[string]provider.InterfaceLinkDefinition),
-		targetLinks: make(map[string]provider.InterfaceLinkDefinition),
+		sourceLinks:       make(map[string]provider.InterfaceLinkDefinition),
+		targetLinks:       make(map[string]provider.InterfaceLinkDefinition),
+		failedSourceLinks: make(map[string]provider.InterfaceLinkDefinition),
+		failedTargetLinks: make(map[string]provider.InterfaceLinkDefinition),
 	}
 
 	wasmcloudprovider, err := provider.New(
@@ -69,12 +71,24 @@ func run() error {
 
 func (p *Provider) handleNewSourceLink(link provider.InterfaceLinkDefinition) error {
 	log.Println("Handling new source link", link)
+	err := p.establishSourceLink(link)
+	if err != nil {
+		log.Println("Failed to establish source link", link, err)
+		p.failedSourceLinks[link.Target] = link
+		return err
+	}
 	p.sourceLinks[link.Target] = link
 	return nil
 }
 
 func (p *Provider) handleNewTargetLink(link provider.InterfaceLinkDefinition) error {
 	log.Println("Handling new target link", link)
+	err := p.establishTargetLink(link)
+	if err != nil {
+		log.Println("Failed to establish target link", link, err)
+		p.failedTargetLinks[link.SourceID] = link
+		return err
+	}
 	p.targetLinks[link.SourceID] = link
 	return nil
 }


### PR DESCRIPTION
## Feature or Problem
Identify which links did not pass validation and pass them back to the wasm cloud provider.

## Related Issues
Possibly fixes #10 depending on what type of information you want passed by to the cloud provider. Is it enough to just identify which links failed, or should we also include a message on what failed. I left the code open ended so that we could discuss based on the needs of the cloud provider.

## Tech Debt
I also corrected some local errors that were causing this code not to compile. `slog` is behind and does not work on `1.22` only `1.20`. Also Golang does not have a `patch` version, only `major`.`minor`