### PR TITLE
chore: Setting up vanity URL

### DIFF
--- a/examples/keyvalue-inmemory/go.mod
+++ b/examples/keyvalue-inmemory/go.mod
@@ -4,9 +4,9 @@ go 1.22.3
 
 require (
 	github.com/bytecodealliance/wrpc/go v0.0.0-20240821200644-5f4408308a27
-	github.com/wasmCloud/provider-sdk-go v0.0.0-20240124183610-1a92f8d04935
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/trace v1.28.0
+	go.wasmcloud.dev/provider v0.0.0-20240124183610-1a92f8d04935
 )
 
 require (
@@ -42,4 +42,4 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 )
 
-replace github.com/wasmCloud/provider-sdk-go => ../..
+replace go.wasmcloud.dev/provider => ../..

--- a/examples/keyvalue-inmemory/go.sum
+++ b/examples/keyvalue-inmemory/go.sum
@@ -29,6 +29,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/wasmCloud/provider-sdk-go v0.0.0-20240822191620-c7544c42f18d h1:8r/C1/DLI4Tshqpv1a0H13k/LkI/nK9QHcWcnRks8ac=
+github.com/wasmCloud/provider-sdk-go v0.0.0-20240822191620-c7544c42f18d/go.mod h1:YeUIfCLp0cZMDTppJcGv03mBZcnJrjLCZl1XOlsej/o=
 go.opentelemetry.io/otel v1.28.0 h1:/SqNcYk+idO0CxKEUOtKQClMK/MimZihKYMruSMViUo=
 go.opentelemetry.io/otel v1.28.0/go.mod h1:q68ijF8Fc8CnMHKyzqL6akLO46ePnjkgfIMIjUIX9z4=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240801233905-f7977e064c9c h1:cj2Wk3ZNyGRDmQqjK0QJdS+teMQnvv7+uTiKNqnSjTo=

--- a/examples/keyvalue-inmemory/keyvalue.go
+++ b/examples/keyvalue-inmemory/keyvalue.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 
 	wrpc "github.com/bytecodealliance/wrpc/go"
-	"github.com/wasmCloud/provider-sdk-go"
 	"github.com/wasmCloud/provider-sdk-go/examples/keyvalue-inmemory/bindings/exports/wrpc/keyvalue/store"
 	"go.opentelemetry.io/otel/trace"
+	"go.wasmcloud.dev/provider"
 )
 
 var (

--- a/examples/keyvalue-inmemory/main.go
+++ b/examples/keyvalue-inmemory/main.go
@@ -8,9 +8,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/wasmCloud/provider-sdk-go"
 	server "github.com/wasmCloud/provider-sdk-go/examples/keyvalue-inmemory/bindings"
 	"go.opentelemetry.io/otel"
+	"go.wasmcloud.dev/provider"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wasmCloud/provider-sdk-go
+module go.wasmcloud.dev/provider
 
 go 1.22.2
 


### PR DESCRIPTION
Binds the vanity URL ( `go.wasmcloud.dev/provider` ) setup in https://github.com/wasmCloud/go-vanity-urls/