### PR TITLE
feat: Implement RedactedString for redacting sensitive values from logs

### DIFF
--- a/host.go
+++ b/host.go
@@ -1,9 +1,28 @@
 package provider
 
+import "encoding/json"
+
 const (
 	OtelProtocolHTTP = "Http"
 	OtelProtocolGRPC = "Grpc"
 )
+
+type RedactedString string
+
+func (rs RedactedString) String() string {
+	if rs != "" {
+		return "redacted(string)"
+	}
+	return ""
+}
+
+func (rs RedactedString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rs.String())
+}
+
+func (rs RedactedString) Reveal() string {
+	return string(rs)
+}
 
 type OtelConfig struct {
 	EnableObservability   bool   `json:"enable_observability"`
@@ -32,7 +51,7 @@ type HostData struct {
 	Config                 map[string]string          `json:"config,omitempty"`
 	Secrets                map[string]SecretValue     `json:"secrets,omitempty"`
 	HostXKeyPublicKey      string                     `json:"host_xkey_public_key,omitempty"`
-	ProviderXKeyPrivateKey SecretStringValue          `json:"provider_xkey_private_key,omitempty"`
+	ProviderXKeyPrivateKey RedactedString             `json:"provider_xkey_private_key,omitempty"`
 	DefaultRPCTimeoutMS    *uint64                    `json:"default_rpc_timeout_ms,omitempty"`
 	StructuredLogging      bool                       `json:"structured_logging,omitempty"`
 	LogLevel               *Level                     `json:"log_level,omitempty"`

--- a/host_test.go
+++ b/host_test.go
@@ -1,0 +1,30 @@
+package provider
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestRedactedStringLogging(t *testing.T) {
+	var buf bytes.Buffer
+	secret := "its-a-secret"
+	redactedString := RedactedString(secret)
+
+	jsonSlog := slog.New(slog.NewJSONHandler(&buf, nil))
+	jsonSlog.Info("jsonSlog", "redactedString", redactedString)
+
+	if !strings.Contains(buf.String(), "\"redactedString\":\"redacted(string)\"") || strings.Contains(buf.String(), secret) {
+		t.Error("json slog handler output should not have contained the secret string")
+	}
+
+	buf.Reset()
+
+	textSlog := slog.New(slog.NewTextHandler(&buf, nil))
+	textSlog.Info("textSlog", "redactedString", redactedString)
+
+	if !strings.Contains(buf.String(), "redactedString=redacted(string)") || strings.Contains(buf.String(), secret) {
+		t.Error("text slog handler should not have contained the secret string")
+	}
+}

--- a/models.go
+++ b/models.go
@@ -22,7 +22,7 @@ func LatticeTopics(h HostData, providerXkey nkeys.KeyPair) Topics {
 	// public key and the provider xkey private key.
 	var providerLinkPutKey string
 	publicKey, err := providerXkey.PublicKey()
-	if len(h.HostXKeyPublicKey) == 0 || len(h.ProviderXKeyPrivateKey.Reveal()) == 0 || err != nil {
+	if h.HostXKeyPublicKey == "" || h.ProviderXKeyPrivateKey == "" || err != nil {
 		providerLinkPutKey = h.ProviderKey
 	} else {
 		providerLinkPutKey = publicKey

--- a/models_test.go
+++ b/models_test.go
@@ -13,7 +13,7 @@ func TestLatticeTopics(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected err to be nil, got: %v", err)
 	}
-	wasmCloudOneDotZero := HostData{ProviderKey: "providerfoo", LatticeRPCPrefix: "lattice123", ProviderXKeyPrivateKey: SecretStringValue{value: ""}, HostXKeyPublicKey: ""}
+	wasmCloudOneDotZero := HostData{ProviderKey: "providerfoo", LatticeRPCPrefix: "lattice123", ProviderXKeyPrivateKey: RedactedString(""), HostXKeyPublicKey: ""}
 	OneDotZeroTopics := LatticeTopics(wasmCloudOneDotZero, xkey)
 
 	// Test LATTICE_LINK_GET
@@ -55,7 +55,7 @@ func TestLatticeTopics(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected err to be nil, got: %v", err)
 	}
-	wasmCloudOneDotOne := HostData{ProviderKey: "providerfoo", LatticeRPCPrefix: "lattice123", ProviderXKeyPrivateKey: SecretStringValue{value: string(xkeyPrivateKey)}, HostXKeyPublicKey: xkeyPublicKey}
+	wasmCloudOneDotOne := HostData{ProviderKey: "providerfoo", LatticeRPCPrefix: "lattice123", ProviderXKeyPrivateKey: RedactedString(string(xkeyPrivateKey)), HostXKeyPublicKey: xkeyPublicKey}
 	OneDotOneTopics := LatticeTopics(wasmCloudOneDotOne, xkey)
 
 	// Test LATTICE_LINK_GET

--- a/provider.go
+++ b/provider.go
@@ -168,17 +168,17 @@ func New(options ...ProviderHandler) (*WasmcloudProvider, error) {
 	}
 
 	var providerXkey nkeys.KeyPair
-	if len(hostData.ProviderXKeyPrivateKey.Reveal()) == 0 {
+	if hostData.ProviderXKeyPrivateKey != "" {
+		providerXkey, err = nkeys.FromCurveSeed([]byte(hostData.ProviderXKeyPrivateKey.Reveal()))
+		if err != nil {
+			logger.Error("failed to create provider xkey from private key", slog.Any("error", err))
+			return nil, err
+		}
+	} else {
 		// If the provider xkey is not provided, secrets won't be sent to the provider
 		// so we can just create a new xkey
 		providerXkey, err = nkeys.CreateCurveKeys()
 		if err != nil {
-			return nil, err
-		}
-	} else {
-		providerXkey, err = nkeys.FromCurveSeed([]byte(hostData.ProviderXKeyPrivateKey.Reveal()))
-		if err != nil {
-			logger.Error("failed to create provider xkey from private key", slog.Any("error", err))
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Feature or Problem

This change addresses 2 problems:

1. Rust serializes host data as a string, but Go would expect to deserialize it from a JSON object (`"provider_xkey_private_key": "<xkey-seed-value-goes-here>"` vs. `"provider_xkey_private_key": { "value": "<xkey-seed-value-goes-here>" }`), so I'm not sure this should've ever worked.
2. Given the above, it was very challenging / impossible to instantiate HostData externally for the purposes of mocking it in testing.

`RedactedString(...)` can be used for the same purposes since it implements `String()` and `MarshalJSON()` for handling accidental logging, and keeps the `Reveal()` interface for when you intentionally want to make use of the contained value.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
