### PR TITLE
feat: tidy verbose telemetry service name

### DIFF
--- a/observability.go
+++ b/observability.go
@@ -124,7 +124,7 @@ func newLoggerProvider(ctx context.Context, config OtelConfig, serviceResource *
 	return loggerProvider, nil
 }
 
-func newServiceResource(ctx context.Context, name string) (*resource.Resource, error) {
+func newServiceResource(ctx context.Context, hostData HostData) (*resource.Resource, error) {
 	providerBinary, err := os.Executable()
 	if err != nil {
 		return nil, err
@@ -132,8 +132,10 @@ func newServiceResource(ctx context.Context, name string) (*resource.Resource, e
 
 	return resource.New(ctx,
 		resource.WithAttributes(
-			semconv.ServiceNameKey.String(filepath.Base(providerBinary)),
-			semconv.ServiceInstanceIDKey.String(name),
+			semconv.ServiceNameKey.String(hostData.ProviderKey),
+			semconv.HostIDKey.String(hostData.HostID),
+			semconv.ContainerIDKey.String(hostData.InstanceID),
+			semconv.ContainerImageNameKey.String(filepath.Base(providerBinary)),
 		),
 	)
 }

--- a/observability.go
+++ b/observability.go
@@ -134,8 +134,8 @@ func newServiceResource(ctx context.Context, hostData HostData) (*resource.Resou
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String(hostData.ProviderKey),
 			semconv.HostIDKey.String(hostData.HostID),
-			semconv.ContainerIDKey.String(hostData.InstanceID),
-			semconv.ContainerImageNameKey.String(filepath.Base(providerBinary)),
+			semconv.ServiceInstanceIDKey.String(hostData.InstanceID),
+			semconv.ProcessExecutableNameKey.String(filepath.Base(providerBinary)),
 		),
 	)
 }

--- a/provider.go
+++ b/provider.go
@@ -120,7 +120,7 @@ func NewWithHostDataSource(source io.Reader, options ...ProviderHandler) (*Wasmc
 	propagator := newPropagator()
 	otel.SetTextMapPropagator(propagator)
 
-	serviceResource, err := newServiceResource(context.Background(), hostData.ProviderKey)
+	serviceResource, err := newServiceResource(context.Background(), hostData)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Feature or Problem
Tidy up the open telemetry attributes:
- Replace provider executable name in favour of the Provider Key for `service.name`
    - Provider Key is unique to each provider instance whereas the executable name is not
- Add Host ID to `host.id`
- Add Instance ID to `container.id`
- Move provider binary name to `container.image.name`

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
Tested using some simple modifications to the http-server example which can be found in [this Gist](https://gist.github.com/jamesstocktonj1/b07495151c1142d122f66483fae3a878). The tracer collecter is Jaeger.

### Before
![Screenshot from 2024-10-05 14-06-20](https://github.com/user-attachments/assets/7fa51676-c4fb-4985-aa2d-75bc22617f88)

### After
![Screenshot from 2024-10-05 14-06-44](https://github.com/user-attachments/assets/c615d478-e7c6-4c63-b16d-1e43a4d6037c)